### PR TITLE
feat: Implement local and Google OAuth login

### DIFF
--- a/client/src/LoginPage.tsx
+++ b/client/src/LoginPage.tsx
@@ -127,6 +127,7 @@ const LoginPage: React.FC = () => {
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}
                 className="w-full py-2 px-4 border border-gray-300 rounded-lg shadow-sm text-sm font-medium text-gray-700 bg-white hover:bg-gray-50"
+                onClick={() => window.location.href = '/api/auth/google'}
               >
                 Google
               </motion.button>


### PR DESCRIPTION
Implemented the following:

- Updated `AuthContext` to connect to backend `/api/auth/login` for local authentication.
- Implemented `logout` in `AuthContext` to call `/api/auth/logout`.
- Added Google OAuth button to `LoginPage` to redirect to `/api/auth/google`.
- Updated `AuthContext` to fetch user from `/api/auth/user` on load to handle OAuth callbacks and existing sessions.
- Refined demo user handling in `AuthContext`.